### PR TITLE
Add EXIF Orientation Support

### DIFF
--- a/mthumb.php
+++ b/mthumb.php
@@ -1052,6 +1052,27 @@ if (!class_exists('mthumb')) : /**
 				}
 			}
 
+			// exif rotation support
+			if (preg_match('/^image\/(?:jpg|jpeg)$/i', $mimeType)){ 
+				$exif = exif_read_data($localImage);
+
+				if ($exif && array_key_exists('Orientation', $exif)) {
+					$ort = $exif['Orientation'];
+
+					switch ($ort) {
+						case 3: // 180 rotate left
+							$canvas = imagerotate($canvas, 180, 0);
+							break;
+						case 6: // 	90 rotate right
+							$canvas = imagerotate($canvas, -90, 0);
+							break;
+						case 8: // 	90 rotate left
+							$canvas = imagerotate($canvas, 90, 0);
+							break;
+					}
+				}
+			}
+
 			// sharpen image
 			if ($sharpen && function_exists('imageconvolution')) {
 


### PR DESCRIPTION
Image with exif orientation metadata (e.g. photos taken with iphones) will be rotated correctly.

Based on https://github.com/parkscom/timthumb/commit/053e18c9ad60cb7808c6071be60e77091a39b5d2